### PR TITLE
Fixed issue with sass 3.2 passing parameters

### DIFF
--- a/compass/stylesheets/_color-schemer.sass
+++ b/compass/stylesheets/_color-schemer.sass
@@ -105,7 +105,7 @@ $equalize: false !default
 @function shade($color, $percent)
   @return mix(black, $color, $percent)
 
-@function color-schemer($color-location:$primary,$base-color:$base-color,$color-scheme:$color-scheme,$hue-offset:$hue-offset)
+@function color-schemer($color-location:$color-location,$base-color:$base-color,$color-scheme:$color-scheme,$hue-offset:$hue-offset)
   // Primary, just return the base-color.
   @if $equalize
     $base-color: equalize($base-color)


### PR DESCRIPTION
Explicitly passing named variables into color-schemer() to avoid a sass
error "Function color-schemer is missing argument $foo"

Hi there (again),

I started getting an error after updating to Sass 3.2 final, "Function color-schemer missing argument $base-color", I don't really understand it as the Sass changelog only refers to "Sass functions are now more strict about how keyword arguments can be passed", and we're not passing keywords.

Anyway, this seems to fix it.
