### PR TITLE
Update all blend-mode references to blend-modes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source :rubygems
 
-gem 'sass',         ">= 3.2.1" 
-gem 'blend-mode',   ">= 0.0.1" 
-gem 'compass',      ">= 0.12.2" 
+gem 'sass',         ">= 3.2.1"
+gem 'blend-modes',   ">= 0.0.1"
+gem 'compass',      ">= 0.12.2"

--- a/color-schemer.gemspec
+++ b/color-schemer.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.5.2}
   s.summary = %q{Create color schemes with ease.}
   s.add_dependency(%q<compass>, ["~> 0.12"])
-  s.add_dependency(%q<blend-mode>, ["~> 0.0.1"])
+  s.add_dependency(%q<blend-modes>, ["~> 0.0.1"])
 end

--- a/example/config.rb
+++ b/example/config.rb
@@ -1,5 +1,5 @@
 # require 'color-schemer'
-require 'blend-mode'
+require 'blend-modes'
 
 # Set this to the root of your project when deployed:
 add_import_path '../stylesheets'

--- a/lib/color-schemer.rb
+++ b/lib/color-schemer.rb
@@ -1,9 +1,9 @@
 require 'compass'
-require 'blend-mode'
+require 'blend-modes'
 Compass::Frameworks.register("color-schemer", :path => "#{File.dirname(__FILE__)}/..")
 
 module ColorSchemer
-  
+
   VERSION = "0.2.3"
   DATE = "2011-09-15"
 

--- a/stylesheets/_color-schemer.scss
+++ b/stylesheets/_color-schemer.scss
@@ -1,4 +1,4 @@
-@import "blend-mode";
+@import "blend-modes";
 
 // Defaults
 $cs-primary           : #f00 !default;


### PR DESCRIPTION
A few months ago [blend-mode was renamed blend-modes](https://github.com/heygrady/scss-blend-modes/commit/b8f405831e48b0e99e158eb68c77b609f5b41652). Updated all references so color-schemer can find blend-mode(s) again.
