### PR TITLE
Updating Compass dependency so it can work with 1.0.0.alpha releases and bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "color-schemer",
-  "version": "0.2.5",
+  "version": "0.2.7",
   "main": "stylesheets/_color-schemer.scss",
   "ignore": [
     "**/.*",

--- a/color-schemer.gemspec
+++ b/color-schemer.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.rubyforge_project = %q{color-schemer}
   s.rubygems_version = %q{1.5.2}
   s.summary = %q{Create color schemes with ease.}
-  s.add_dependency(%q<compass>, ["~> 0.12"])
+  s.add_dependency(%q<compass>, [">= 0.12"])
   s.add_dependency(%q<compass-blend-modes>, ["~> 0.0.2"])
 end


### PR DESCRIPTION
Bower would not install because there was no tag:

```
$ bower install sass-toolkit
bower not-cached    git://github.com/Team-Sass/color-schemer.git#>=0.2.3
bower resolve       git://github.com/Team-Sass/color-schemer.git#>=0.2.3
bower cached        git://github.com/Snugug/Sassy-Strings.git#1.0.0
bower validate      1.0.0 against git://github.com/Snugug/Sassy-Strings.git#*
bower cached        git://github.com/Team-Sass/breakpoint.git#2.3.0
bower validate      2.3.0 against git://github.com/Team-Sass/breakpoint.git#>=2.0.2
bower cached        git://github.com/Team-Sass/toolkit.git#1.3.8
bower validate      1.3.8 against git://github.com/Team-Sass/toolkit.git#*
bower ENORESTARGET  No tag found that was able to satisfy >=0.2.3
```

https://github.com/Team-Sass/toolkit/issues/46
